### PR TITLE
Added ContentType to Firebase Analytics logs for "load_success" and "load_error"

### DIFF
--- a/OpenDocumentReader/Document.swift
+++ b/OpenDocumentReader/Document.swift
@@ -104,3 +104,11 @@ class Document: UIDocument {
         parse()
     }
 }
+
+extension Document {
+    
+    var shortenedDocumentUrl: String {
+        return fileURL.absoluteString.prefix(49) + ".." + fileURL.absoluteString.suffix(49)
+    }
+    
+}

--- a/OpenDocumentReader/DocumentViewController.swift
+++ b/OpenDocumentReader/DocumentViewController.swift
@@ -214,7 +214,12 @@ class DocumentViewController: UIViewController, DocumentDelegate {
         
         self.webview.loadHTMLString("<html><h1>Error</h1>Failed to load given document. Please try another one while we are working hard to support as many documents as possible. Feel free to contact us via support@opendocument.app for further questions.</html>", baseURL: nil)
         
-        Analytics.logEvent("load_error", parameters: nil)
+        Analytics.logEvent(
+            "load_error",
+            parameters: [
+                AnalyticsParameterItemName: doc.shortenedDocumentUrl,
+                AnalyticsParameterContentType: fileType
+            ])
     }
     
     func documentLoadingStarted(_ doc: Document) {
@@ -225,7 +230,14 @@ class DocumentViewController: UIViewController, DocumentDelegate {
     func documentLoadingCompleted(_ doc: Document) {
         progressBar.isHidden = true
         
-        Analytics.logEvent("load_success", parameters: nil)
+        let fileType = doc.fileURL.pathExtension.lowercased()
+        
+        Analytics.logEvent(
+            "load_success",
+            parameters: [
+                AnalyticsParameterItemName: doc.shortenedDocumentUrl,
+                AnalyticsParameterContentType: fileType
+            ])
     }
     
     func documentPagesChanged(_ doc: Document) {


### PR DESCRIPTION
In response to [issue 22](https://github.com/TomTasche/OpenDocument.ios/issues/22), added a ContentType log to Firebase Analytics. I noticed you had previously set `AnalyticsParameterItemName` to a shortened Document Url, so I added it as a computed variable `shortenedDocumentUrl` to the `Document` class.